### PR TITLE
Fix etcd_name

### DIFF
--- a/templates/etc/etcd/etcd.conf.erb
+++ b/templates/etc/etcd/etcd.conf.erb
@@ -1,5 +1,5 @@
 #[member]
-ETCD_NAME=<%= scope['etcd::etcd_name'] %>
+ETCD_NAME="<%= scope['etcd::etcd_name'] %>"
 ETCD_DATA_DIR="<%= scope['etcd::data_dir'] %>"
 ETCD_WAL_DIR="<%= scope['etcd::wal_dir'] %>"
 ETCD_SNAPSHOT_COUNTER="<%= scope['etcd::snapshot_counter'] %>"


### PR DESCRIPTION
Whe having a hyphen on the hostname the start fails. Adding the quotes fixes the issue.
