### PR TITLE
Add ability to install etcd from outside this module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,15 @@
 #   Whether you want to kube daemons to start up at boot
 #   Defaults to true
 #
+#  package and service
+# [*manage_package*]
+#   Wheter this module should install etcd.
+#   Defaults to true
+#
+# [*manage_service*]
+#   Wheter this module should manage the etcd service.
+#   Defaults to true
+#
 #  member
 # [*etcd_name*]
 #   Human-readable name for this member.
@@ -191,6 +200,9 @@ class etcd (
   $ensure                      = $etcd::params::ensure,
   $service_ensure              = $etcd::params::service_ensure,
   $service_enable              = $etcd::params::service_enable,
+  # package and service
+  $manage_package              = true
+  $manage_service              = true
   # member
   $etcd_name                   = 'default',
   $data_dir                    = "/var/lib/etcd/${etcd_name}.etcd",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,8 +201,8 @@ class etcd (
   $service_ensure              = $etcd::params::service_ensure,
   $service_enable              = $etcd::params::service_enable,
   # package and service
-  $manage_package              = true
-  $manage_service              = true
+  $manage_package              = true,
+  $manage_service              = true,
   # member
   $etcd_name                   = 'default',
   $data_dir                    = "/var/lib/etcd/${etcd_name}.etcd",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,9 +5,9 @@ class etcd::install {
     package { 'etcd': ensure => $etcd::ensure, }
   } else {
     # make sure /etc/etcd is present
-	file {'/etc/etcd/':
-	  ensure => directory,
-	  before => File['/etc/etcd/etcd.conf'],
-	}
+    file {'/etc/etcd/':
+      ensure => directory,
+      before => File['/etc/etcd/etcd.conf'],
+    }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,5 +3,10 @@
 class etcd::install {
   if $::etcd::mange_package {
     package { 'etcd': ensure => $etcd::ensure, }
+  } else {
+    # make sure /etc/etcd is present
+	file {'/etc/etcd/':
+	  ensure => directory,
+	}
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,7 @@
 # == Class: etcd
 #
 class etcd::install {
-  package { 'etcd': ensure => $etcd::ensure, }
+  if $::etcd::mange_package {
+    package { 'etcd': ensure => $etcd::ensure, }
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@ class etcd::install {
     # make sure /etc/etcd is present
 	file {'/etc/etcd/':
 	  ensure => directory,
+	  before => File['/etc/etcd/etcd.conf'],
 	}
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,8 +3,10 @@
 # Class to manage the etcd service daemon
 #
 class etcd::service {
-  service { 'etcd':
-    ensure => $etcd::service_ensure,
-    enable => $etcd::service_enable,
+  if $::etcd::manage_service {
+    service { 'etcd':
+      ensure => $etcd::service_ensure,
+      enable => $etcd::service_enable,
+    }
   }
 }


### PR DESCRIPTION
This is useful if the os has no packages for etcd like Ubuntu 14.04

```
  # package and service
  $manage_package              = true,
  $manage_service              = true,
```
