### PR TITLE
Add support for Debian based systems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,16 +1,29 @@
 # == Class: etcd::config
 #
 class etcd::config {
-  case $::operatingsystemmajrelease {
-    6       : {
-      file { '/etc/sysconfig/etcd.conf':
-        ensure  => 'file',
-        content => template("${module_name}/etc/etcd/etcd.conf.erb"),
+  case $::osfamily {
+    'RedHat' : {
+      case $::operatingsystemmajrelease {
+        6       : {
+          file { '/etc/sysconfig/etcd.conf':
+            ensure  => 'file',
+            content => template("${module_name}/etc/etcd/etcd.conf.erb"),
+          }
+        }
+        7       : {
+          file { '/etc/etcd/': ensure => 'directory', } ->
+          file { '/etc/etcd/etcd.conf':
+            ensure  => 'file',
+            content => template("${module_name}/etc/etcd/etcd.conf.erb"),
+          }
+        }
+        default : {
+          fail('Unsupported OS.')
+        }
       }
     }
-    7       : {
-      file { '/etc/etcd/': ensure => 'directory', } ->
-      file { '/etc/etcd/etcd.conf':
+    'Debian' : {
+      file { '/etc/default/etcd.conf':
         ensure  => 'file',
         content => template("${module_name}/etc/etcd/etcd.conf.erb"),
       }

--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,9 @@
 			"operatingsystem": "Fedora",
 			"operatingsystemrelease": [ "21"
 			]
+		},
+		{	"operatingsystem": "Debian",
+			"operatingsystemrelease": [ "stretch/sid"]
 		}
 	],
 	"dependencies": [{


### PR DESCRIPTION
Latest changes (support for RHEL6) broke my installation - I was running Debian and Ubuntu with overriden config location, but now I get 'Unsupported system'.
My PR changes the config location if we're running on Debian-based system.
