### PR TITLE
Added option completely enable and disable all clustering options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,11 @@
 #   respond to requests from any of the listed addresses and ports.
 #   default: "http://localhost:2380,http://localhost:7001"
 #
+# [*cluster_enabled*]
+#   If set to false, all clustering options will be omitted from the final config file. Fixes some problems
+#   with older etcd versions.
+#   default: true
+#
 # [*listen_client_urls*]
 #   List of URLs to listen on for client traffic. This flag tells the etcd to accept incoming requests
 #   from the clients on the specified scheme://IP:port combinations. Scheme can be either http or https.
@@ -221,6 +226,7 @@ class etcd (
   $max_wals                    = $etcd::params::max_wals,
   $cors                        = $etcd::params::cors,
   # cluster
+  $cluster_enabled             = $etcd::params::cluster_enabled,
   $listen_peer_urls            = $etcd::params::listen_peer_urls,
   $initial_advertise_peer_urls = $etcd::params::initial_advertise_peer_urls,
   $initial_cluster             = ["${etcd_name}=http://localhost:2380", "${etcd_name}=http://localhost:7001"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,7 @@ class etcd::params {
   $cors = undef
 
   # cluster options
+  $cluster_enabled = true
   $listen_peer_urls = ['http://localhost:2380', 'http://localhost:7001']
   $initial_advertise_peer_urls = ['http://localhost:2380']
   $initial_cluster_state = 'new'

--- a/templates/etc/etcd/etcd.conf.erb
+++ b/templates/etc/etcd/etcd.conf.erb
@@ -23,6 +23,7 @@ ETCD_PROXY_WRITE_TIMEOUT="<%= scope['etcd::proxy_write_timeout'] %>"
 ETCD_PROXY_READ_TIMEOUT="<%= scope['etcd::proxy_read_timeout'] %>"
 #
 <% end -%>
+<% if scope['etcd::cluster_enabled'] %>
 #[cluster]
 ETCD_LISTEN_PEER_URLS="<%= Array(scope['etcd::listen_peer_urls']).join(',') %>"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="<%= Array(scope['etcd::initial_advertise_peer_urls']).join(',') %>"
@@ -41,6 +42,7 @@ ETCD_DISCOVERY_PROXY="<%= scope['etcd::discovery_proxy'] %>"
 <% end -%>
 ETCD_STRICT_RECONFIG_CHECK=<%= scope['etcd::strict_reconfig_check'] %>
 #
+<% end %>
 #[security]
 <% unless [nil, :undefined, :undef, ''].include?(scope['etcd::cert_file']) -%>
 ETCD_CERT_FILE="<%= scope['etcd::cert_file'] %>"


### PR DESCRIPTION
I have added an option to completely disable all clustering from the config file. My version of etcd did not startup correctly when using the class etcd without all options.
