### PR TITLE
Allow for other discovery mechanisms

### DIFF
--- a/templates/etc/etcd/etcd.conf.erb
+++ b/templates/etc/etcd/etcd.conf.erb
@@ -29,7 +29,9 @@ ETCD_PROXY_READ_TIMEOUT=<%= scope['etcd::proxy_read_timeout'] %>
 #[cluster]
 ETCD_LISTEN_PEER_URLS="<%= Array(scope['etcd::listen_peer_urls']).join(',') %>"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="<%= Array(scope['etcd::initial_advertise_peer_urls']).join(',') %>"
+<% unless [nil, :undefined, :undef, ''].include?(scope['etcd::initial_cluster']) -%>
 ETCD_INITIAL_CLUSTER="<%= Array(scope['etcd::initial_cluster']).join(',') %>"
+<% end -%>
 ETCD_INITIAL_CLUSTER_STATE="<%= scope['etcd::initial_cluster_state'] %>"
 ETCD_INITIAL_CLUSTER_TOKEN="<%= scope['etcd::initial_cluster_token'] %>"
 <% unless [nil, :undefined, :undef, ''].include?(scope['etcd::discovery']) -%>


### PR DESCRIPTION
If e.g. `discovery_srv`is set I get a failure of:

```
Mar 30 03:03:05 ip-10-123-3-221 etcd[31536]: error verifying flags, multiple discovery or bootstrap flags are set. Choose one of "initial-cluster", "discovery" or "discovery-srv". See 'etcd --help'.
```

This fixes that if `discovery` or `discovery-srv` are set.