### PR TITLE
adding support for Fedora 25

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class etcd::params {
       case $::operatingsystemmajrelease {
         '6'     : { $config_file_path = '/etc/sysconfig/etcd' }
         '7'     : { $config_file_path = '/etc/etcd/etcd.conf' }
+        '25'    : { $config_file_path = '/etc/etcd/etcd.conf' }
         default : { fail('Unsupported RedHat release.') }
       }
     }


### PR DESCRIPTION
Everything is the same as on CentOS 7 so makes no sense why not supporting Fedora 25