### PR TITLE
added quota-backend-bytes setting to the etcd.conf.erb

### DIFF
--- a/templates/etc/etcd/etcd.conf.erb
+++ b/templates/etc/etcd/etcd.conf.erb
@@ -7,6 +7,7 @@ ETCD_WAL_DIR="<%= scope['etcd::wal_dir'] %>"
 ETCD_SNAPSHOT_COUNT=<%= scope['etcd::snapshot_count'] %>
 ETCD_HEARTBEAT_INTERVAL=<%= scope['etcd::heartbeat_interval'] %>
 ETCD_ELECTION_TIMEOUT=<%= scope['etcd::election_timeout'] %>
+ETCD_QUOTA_BACKEND_BYTES=<%= scope['etcd::quota_backend_bytes'] %>
 ETCD_LISTEN_CLIENT_URLS="<%= Array(scope['etcd::listen_client_urls']).join(',') %>"
 ETCD_ADVERTISE_CLIENT_URLS="<%= Array(scope['etcd::advertise_client_urls']).join(',') %>"
 ETCD_MAX_SNAPSHOTS=<%= scope['etcd::max_snapshots'] %>


### PR DESCRIPTION
added quota-backend-bytes setting to the etcd.conf.erb as it does not exist in the config but in the yml. Tested on:
CentOS Linux release 7.4.1708 (Core)
etcdctl version: 3.1.9
and
CentOS Linux release 7.3.1611 (Core)
etcdctl version 2.3.7
Both using Puppet 4