### PR TITLE
Adjustment on directory creation to work with Ubuntu distribution

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,15 @@
 # == Class: etcd::config
 #
 class etcd::config {
+  if $::osfamily == 'Ubuntu' {
+    file { '/etc/etcd':
+        ensure => 'directory',
+        owner  => 'etcd',
+        group  => 'etcd',
+        mode   => '0755',
+    }
+  }
+
   file { $::etcd::config_file_path:
     ensure  => 'file',
     content => template("${module_name}/etc/etcd/etcd.conf.erb"),

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,10 +3,10 @@
 class etcd::config {
   if $::osfamily == 'Ubuntu' {
     file { '/etc/etcd':
-        ensure => 'directory',
-        owner  => 'etcd',
-        group  => 'etcd',
-        mode   => '0755',
+      ensure => 'directory',
+      owner  => 'etcd',
+      group  => 'etcd',
+      mode   => '0755',
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class etcd::params {
       }
     }
     'Debian' : {
-      $config_file_path = '/etc/default/etcd.conf'
+      $config_file_path = '/etc/default/etcd'
     }
     default  : {
       fail('Unsupported OS.')


### PR DESCRIPTION
As my report in issue #31. It looks like the current module doesn't work with Ubuntu. Also, on ubuntu, the default configuration file for etc should be `/etc/default/etcd` as following systemd file

```
cat /lib/systemd/system/etcd.service
[Unit]
Description=etcd - highly-available key value store
Documentation=https://github.com/coreos/etcd
Documentation=man:etcd
After=network.target
Wants=network-online.target

[Service]
Environment=DAEMON_ARGS=
Environment=ETCD_NAME=%H
Environment=ETCD_DATA_DIR=/var/lib/etcd/default
EnvironmentFile=-/etc/default/%p
Type=notify
User=etcd
PermissionsStartOnly=true
#ExecStart=/bin/sh -c "GOMAXPROCS=$(nproc) /usr/bin/etcd $DAEMON_ARGS"
ExecStart=/usr/bin/etcd $DAEMON_ARGS
Restart=on-abnormal
#RestartSec=10s
LimitNOFILE=65536

[Install]
WantedBy=multi-user.target
Alias=etcd2.service
```