### PR TITLE
Add support for Red Hat EL8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,11 +12,7 @@ class etcd::params {
     'RedHat' : {
       case $::operatingsystemmajrelease {
         '6'     : { $config_file_path = '/etc/sysconfig/etcd' }
-        '7'     : { $config_file_path = '/etc/etcd/etcd.conf' }
-        '24'    : { $config_file_path = '/etc/etcd/etcd.conf' }
-        '25'    : { $config_file_path = '/etc/etcd/etcd.conf' }
-        '26'    : { $config_file_path = '/etc/etcd/etcd.conf' }
-        default : { fail('Unsupported RedHat release.') }
+        default : { $config_file_path = '/etc/etcd/etcd.conf' }
       }
     }
     'Debian' : {

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
 	"operatingsystem_support": [{
 			"operatingsystem": "RedHat",
 			"operatingsystemrelease": [ "6",
-				"7"
+				"7",
+				"8"
 			]
 		},{
 			"operatingsystem": "CentOS",


### PR DESCRIPTION
Add Red Hat EL8 to the list of supported OS.

Update the code that sets the $config_file_path for the Red Hat
OS family. Active releases (except EL6) all use the same config file
path, so this patch eliminates the need to update the code each time
a new OS version is released.